### PR TITLE
Fix stub generator failing when working directory differs from source directory

### DIFF
--- a/tools/LassStubgen.cmake
+++ b/tools/LassStubgen.cmake
@@ -340,7 +340,7 @@ function(Lass_generate_stubs target)
 		set(depfile "${output_json}.d")
 		list(APPEND intermediate_stubdata "${output_json}")
 		set(args
-			"${src_file}"
+			"${abs_path}"
 			${includes}
 			${system_includes}
 			${defines}


### PR DESCRIPTION
The args response file passed to the lass stub generator contained the source file as a relative path (relative to CMAKE_CURRENT_SOURCE_DIR). When the stub generator process was launched from any working directory other than the source directory, libclang could not locate the file and reported "Error parsing translation unit / 1 parse errors found".

Fix by writing the resolved absolute path (abs_path) instead of the original relative src_file into the response file, so the stub generator works regardless of the process working directory.